### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,8 +1,10 @@
-
+cmake_minimum_required(VERSION 3.13)
 
 file(GLOB SOURCES 
-        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/../src/oled/*.cpp"
+        ../src/Adafruit_SSD1306.cpp
+        ../src/Adafruit_GFX.cpp
+        ../src/oled/AdafruitSSD1306I2c.cpp
+        ../src/oled/AdafruitSSD1306Spi.cpp
 )
 
 add_library(AdafruitGFXNativePort ${SOURCES})
@@ -12,8 +14,8 @@ target_compile_definitions(AdafruitGFXNativePort
 )
 
 target_include_directories(AdafruitGFXNativePort PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
-        ${CMAKE_CURRENT_LIST_DIR}/../Fonts
+        ../src
+        ..
 )
 
 target_link_libraries(AdafruitGFXNativePort PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,14 +5,14 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/oled/*.cpp"
 )
 
-add_library(AdafruitGFXNativePort ${SOURCES})
+add_library(AdafruitGFXNativePort INTERFACE ${SOURCES})
 
 target_compile_definitions(AdafruitGFXNativePort
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(AdafruitGFXNativePort PUBLIC
+target_include_directories(AdafruitGFXNativePort INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(AdafruitGFXNativePort PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)
+target_link_libraries(AdafruitGFXNativePort INTERFACE pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,17 +1,18 @@
 
-add_library(AdafruitGFXNativePort
-        ../src/Adafruit_SSD1306.cpp
-        ../src/Adafruit_GFX.cpp
-        ../src/oled/AdafruitSSD1306I2c.cpp
-        ../src/oled/AdafruitSSD1306Spi.cpp
+
+file(GLOB SOURCES 
+        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/../src/oled/*.cpp"
 )
+
+add_library(AdafruitGFXNativePort ${SOURCES})
 
 target_compile_definitions(AdafruitGFXNativePort
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(AdafruitGFXNativePort PUBLIC
-        ${PROJECT_SOURCE_DIR}/mbed_lib/Adafruit-GFX-mbed-fork/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(AdafruitGFXNativePort PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,14 +5,14 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/oled/*.cpp"
 )
 
-add_library(AdafruitGFXNativePort INTERFACE ${SOURCES})
+add_library(AdafruitGFXNativePort ${SOURCES})
 
 target_compile_definitions(AdafruitGFXNativePort
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(AdafruitGFXNativePort INTERFACE
+target_include_directories(AdafruitGFXNativePort PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(AdafruitGFXNativePort INTERFACE pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)
+target_link_libraries(AdafruitGFXNativePort PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,13 +1,11 @@
 cmake_minimum_required(VERSION 3.13)
 
-file(GLOB SOURCES 
+add_library(AdafruitGFXNativePort 
         ../src/Adafruit_SSD1306.cpp
         ../src/Adafruit_GFX.cpp
         ../src/oled/AdafruitSSD1306I2c.cpp
         ../src/oled/AdafruitSSD1306Spi.cpp
 )
-
-add_library(AdafruitGFXNativePort ${SOURCES})
 
 target_compile_definitions(AdafruitGFXNativePort
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -13,6 +13,7 @@ target_compile_definitions(AdafruitGFXNativePort
 
 target_include_directories(AdafruitGFXNativePort PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
+        ${CMAKE_CURRENT_LIST_DIR}/../Fonts
 )
 
 target_link_libraries(AdafruitGFXNativePort PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.